### PR TITLE
feat: make manifest lifecycle optional for non-plugin deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # deno-deploy
 
-Provisions Deno Deploy apps, syncs Deno environment variables, and maintains `dist/*` manifest artifacts for UbiquityOS plugins.
+Provisions Deno Deploy apps, syncs Deno environment variables, and optionally maintains `dist/*` manifest artifacts for UbiquityOS plugins.
 
 ## Behavior
 
 - One local-source Deno Deploy app is managed per Git branch.
 - `main` uses the unsuffixed base app slug. Every other branch uses `<base-app>-<branch-suffix>`, capped at 32 total characters.
 - Long branch names are truncated to fit the 32-character cap. No hash or other disambiguator is appended, so collisions are accepted by design.
-- `provision` creates a missing branch app through the Deno API when needed, always syncs runtime and build env vars to Deno `production`, deploys the branch app from the current workspace with `--prod`, generates `manifest.json` in GitHub Actions, and publishes it to `dist/<branch>`.
-- After a successful deploy, `provision` updates `dist/<branch>/manifest.json` inline with the stable branch app URL `https://<app-slug>.<org-slug>.deno.net`.
+- `provision` creates a missing branch app through the Deno API when needed, always syncs runtime env vars to Deno `production`, deploys the branch app from the current workspace with `--prod`, and always outputs the stable branch app URL `https://<app-slug>.<org-slug>.deno.net`.
+- When `buildManifest=true`, `provision` also syncs manifest build env vars, generates `manifest.json` in GitHub Actions, updates its `homepage_url`, and publishes it to `dist/<branch>`.
+- When `buildManifest=false`, manifest generation, manifest homepage updates, and `dist/<branch>` manifest publication are skipped.
 - `delete` removes both the paired Deno branch app and the paired `dist/<branch>` branch.
 
 ## Inputs
@@ -18,11 +19,12 @@ Provisions Deno Deploy apps, syncs Deno environment variables, and maintains `di
 - `organization`: Optional Deno Deploy organization slug. When omitted, `provision` first infers it from the token and then falls back to `DENO_ORG_NAME` when available.
 - `app`: Optional base Deno Deploy app slug override. Defaults to the sanitized repository name. `main` uses this value directly; all other branches append a truncated branch suffix within the 32-character total slug cap.
 - `entrypoint`: App runtime entrypoint. Defaults to `src/deno.ts`.
+- `buildManifest`: Whether plugin manifest generation, `homepage_url` writes, and `dist/*` manifest publication should run. Defaults to `true`. Set this to `false` for non-plugin Deno apps such as `ubiquity-os-kernel`.
 
 ## Outputs
 
 - `app_slug`: Resolved Deno app slug.
-- `homepage_url`: Published stable branch app URL written into `dist/*/manifest.json` when available.
+- `homepage_url`: Resolved stable branch app URL. Written into `dist/*/manifest.json` only when `buildManifest=true`.
 
 ## Environment Sync
 
@@ -31,22 +33,28 @@ Provisions Deno Deploy apps, syncs Deno environment variables, and maintains `di
 - GitHub environment selection still happens in the consumer workflow:
   - `main` and `demo` should use the GitHub `main` environment
   - all other branches should use the GitHub `development` environment
-- Managed manifest identity env vars are always synced:
+- Managed branch identity env vars are always synced:
   - `REF_NAME` to both runtime `production` and build
-- Build-only env vars are always synced:
+- Manifest-specific build env vars are synced only when `buildManifest=true`:
   - `PLUGIN_MANIFEST_REPOSITORY`
   - `PLUGIN_MANIFEST_PRODUCTION_BRANCH=main`
 - Reserved `DENO_*` names from the workflow environment are excluded automatically.
 
 ## Build Config
 
-The action treats the Deno dashboard config as the source of truth. It applies:
+The action treats the Deno dashboard config as the source of truth. It always applies:
+
+- `runtime.type=dynamic`
+- `runtime.entrypoint=<input entrypoint>`
+- `unstable` merged with `kv`
+
+When `buildManifest=true`, it also applies:
 
 - `install`: `deno install`
 - `build`: `deno x -y @ubiquity-os/plugin-manifest-tool@latest --repository <owner>/<repo> --production-branch main`
 - `predeploy`: `deno install`
 
-Repository identity for Deno builds comes from the persisted Build-context variable `PLUGIN_MANIFEST_REPOSITORY`.
+Repository identity for Deno manifest builds comes from the persisted Build-context variable `PLUGIN_MANIFEST_REPOSITORY`.
 
 Do not commit a `deploy` block in tracked `deno.json` or `deno.jsonc`. `provision` will fail fast if it finds one, because source config would override the action-managed dashboard config.
 
@@ -57,16 +65,15 @@ During `provision`, the action runs:
 - `POST /v2/apps` when the app does not exist yet, using the managed config and synced env vars as app defaults
 - `PATCH /v2/apps/{slug}` for existing apps before deploy
 - `deno --unstable-kv deploy . --config <temporary deno.json|deno.jsonc> --prod` as the single production deployment step for both newly created and existing branch apps
-- `deno install`
-- `deno x -y @ubiquity-os/plugin-manifest-tool@latest`
-This can create or update `manifest.json`, a temporary workspace `deno.json` or `deno.jsonc`, `node_modules`, and related install artifacts in the checked-out workspace. Before each direct deploy, the action removes `node_modules` so Deno uploads only the workspace source, stages a standard Deno config file into the workspace for the upload itself, then restores the original config state after the deploy attempt. The staged config preserves the repo's tracked non-`deploy` Deno settings and always includes `unstable: ["kv"]` so `Deno.openKv()` is available during the deploy runtime.
+- `deno install` and `deno x -y @ubiquity-os/plugin-manifest-tool@latest` only when `buildManifest=true`
+When `buildManifest=true`, this can create or update `manifest.json`, a temporary workspace `deno.json` or `deno.jsonc`, `node_modules`, and related install artifacts in the checked-out workspace. Before each direct deploy, the action removes `node_modules` so Deno uploads only the workspace source, stages a standard Deno config file into the workspace for the upload itself, then restores the original config state after the deploy attempt. The staged config preserves the repo's tracked non-`deploy` Deno settings and always includes `unstable: ["kv"]` so `Deno.openKv()` is available during the deploy runtime.
 
 On first provision, this metadata-first create path avoids the extra bootstrap build that `deno deploy create --source local` would otherwise start before the explicit `--prod` deploy. The deploy step always includes `--unstable-kv` so workers that call `Deno.openKv()` can build without extra consumer-side workflow flags.
 
 ## Requirements
 
 - Run `actions/checkout@v6` before `provision`.
-- Grant `contents: write` so the action can create/update `dist/*` branches.
+- Grant `contents: write` so the action can create/update `dist/*` branches when `buildManifest=true`, and so `delete` can remove paired `dist/*` branches.
 - Use a Deno Deploy token with access to the target organization.
 - Optionally wire `DENO_ORG_NAME` from `${{ vars.DENO_ORG_NAME }}` if you want a deterministic fallback when token-based organization inference is unavailable.
 - Configure consumer workflows so `main` and `demo` use the GitHub `main` environment, while all other branches use the GitHub `development` environment.
@@ -101,6 +108,7 @@ jobs:
           token: ${{ secrets.DENO_DEPLOY_TOKEN }}
           app: ${{ vars.DENO_PROJECT_NAME }}
           entrypoint: src/worker.ts
+          buildManifest: true
 
   delete-branch-app:
     if: github.event_name == 'delete'
@@ -137,6 +145,7 @@ deno run \
   --default-branch development \
   --app command-start-stop-demo \
   --entrypoint src/worker.ts \
+  --build-manifest=true \
   --env-file ./local.env \
   --dry-run
 ```

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Entrypoint used for the app runtime configuration."
     required: false
     default: "src/deno.ts"
+  buildManifest:
+    description: "Whether plugin manifest generation, homepage updates, and dist/* manifest publication should run."
+    required: false
+    default: "true"
 outputs:
   app_slug:
     description: "Resolved Deno Deploy app slug."
@@ -26,7 +30,7 @@ outputs:
     description: "Resolved Deno Deploy organization slug."
     value: ${{ steps.provision.outputs.organization_slug }}
   homepage_url:
-    description: "Published homepage_url written to dist/* manifest.json when available."
+    description: "Resolved stable Deno app homepage URL. Written to dist/* manifest.json only when buildManifest is enabled."
     value: ${{ steps.provision.outputs.homepage_url }}
 runs:
   using: "composite"
@@ -237,6 +241,7 @@ runs:
         DENO_API_TOKEN: ${{ inputs.token }}
         DENO_APP_SLUG: ${{ steps.resolve.outputs.app_slug }}
         DENO_ORG_NAME: ${{ env.DENO_ORG_NAME }}
+        BUILD_MANIFEST: ${{ inputs.buildManifest }}
         ENTRYPOINT: ${{ inputs.entrypoint }}
         GITHUB_OWNER: ${{ github.repository_owner }}
         GITHUB_REPO: ${{ github.event.repository.name }}

--- a/scripts/lib/deno_cli_orgs.js
+++ b/scripts/lib/deno_cli_orgs.js
@@ -80,6 +80,7 @@ export async function inferOrganizationSlugFromToken({
       "--quiet",
       "--allow-env=DENO_DEPLOY_TOKEN,DENO_CONSOLE_URL,__IS_WSL_TEST__",
       "--allow-net=api.deno.com,console.deno.com",
+      "--allow-sys=osRelease",
       workerPath.href,
     ],
     env: {

--- a/scripts/lib/deno_cli_orgs.js
+++ b/scripts/lib/deno_cli_orgs.js
@@ -80,6 +80,7 @@ export async function inferOrganizationSlugFromToken({
       "--quiet",
       "--allow-env=DENO_DEPLOY_TOKEN,DENO_CONSOLE_URL,__IS_WSL_TEST__",
       "--allow-net=api.deno.com,console.deno.com",
+      "--allow-read=/proc/version,/proc/sys/fs/binfmt_misc/WSLInterop,/run/WSL",
       "--allow-sys=osRelease",
       workerPath.href,
     ],

--- a/scripts/provision.js
+++ b/scripts/provision.js
@@ -131,27 +131,37 @@ function collectManagedRuntimeEnvironmentVariables({ contextName, refName }) {
   ];
 }
 
-function collectBuildEnvironmentVariables({ repository, refName }) {
-  const envVars = [
-    {
+export function collectBuildEnvironmentVariables({
+  repository,
+  refName,
+  buildManifest = true,
+}) {
+  const envVars = [];
+
+  if (buildManifest) {
+    envVars.push({
       key: "PLUGIN_MANIFEST_PRODUCTION_BRANCH",
       value: "main",
       secret: false,
       contexts: ["build"],
-    },
-    {
+    });
+    envVars.push({
       key: "PLUGIN_MANIFEST_REPOSITORY",
       value: repository,
       secret: false,
       contexts: ["build"],
-    },
+    });
+  }
+
+  envVars.push(
     {
       key: "REF_NAME",
       value: refName,
       secret: false,
       contexts: ["build"],
     },
-  ];
+  );
+
   return envVars;
 }
 
@@ -178,14 +188,19 @@ function mergeUnstableFlags(sourceConfig) {
   return merged;
 }
 
-export function buildConfig(entrypoint, repository, sourceConfig = {}) {
+export function buildConfig(
+  entrypoint,
+  repository,
+  sourceConfig = {},
+  buildManifest = true,
+) {
   const runtime = isPlainObject(sourceConfig.runtime)
     ? sourceConfig.runtime
     : {};
 
   return {
     ...sourceConfig,
-    ...buildManagedCommands(repository),
+    ...(buildManifest ? buildManagedCommands(repository) : {}),
     unstable: mergeUnstableFlags(sourceConfig),
     runtime: {
       ...runtime,
@@ -645,6 +660,12 @@ async function main() {
   );
   const githubToken = getStringOption(args, "github-token", "GITHUB_TOKEN");
   const dryRun = getBooleanOption(args, "dry-run", "DRY_RUN", false);
+  const buildManifest = getBooleanOption(
+    args,
+    "build-manifest",
+    "BUILD_MANIFEST",
+    true,
+  );
   const denoApiBaseUrl = getStringOption(
     args,
     "deno-api-base-url",
@@ -685,10 +706,16 @@ async function main() {
   const buildEnvVars = collectBuildEnvironmentVariables({
     repository,
     refName,
+    buildManifest,
   });
   const sourceConfigState = await readTrackedSourceConfig(repoRoot);
   const patchPayload = {
-    config: buildConfig(entrypoint, repository, sourceConfigState.config),
+    config: buildConfig(
+      entrypoint,
+      repository,
+      sourceConfigState.config,
+      buildManifest,
+    ),
     env_vars: [...runtimeEnvVars, ...managedRuntimeEnvVars, ...buildEnvVars],
   };
 
@@ -705,24 +732,32 @@ async function main() {
     return;
   }
 
-  if (!githubToken) {
+  if (buildManifest && !githubToken) {
     throw new Error(
       "github-token is required to publish manifest.json to dist branches.",
     );
   }
 
-  await prepareWorkspaceManifest(repoRoot, manifestToolPath);
+  if (buildManifest) {
+    await prepareWorkspaceManifest(repoRoot, manifestToolPath);
+  } else {
+    notice(
+      "Manifest lifecycle is disabled for this deploy. Skipping manifest generation, homepage updates, and dist branch publication.",
+    );
+  }
 
   const deno = new DenoApiClient({
     token,
     baseUrl: denoApiBaseUrl,
   });
-  const github = new GitHubApiClient({
-    token: githubToken,
-    owner: githubOwner,
-    repo: githubRepo,
-    baseUrl: githubApiBaseUrl,
-  });
+  const github = buildManifest
+    ? new GitHubApiClient({
+      token: githubToken,
+      owner: githubOwner,
+      repo: githubRepo,
+      baseUrl: githubApiBaseUrl,
+    })
+    : null;
 
   const existingApp = await deno.getApp(appSlug);
   const { organization: effectiveOrganization, source: organizationSource } =
@@ -795,19 +830,23 @@ async function main() {
     sourceConfigFileName: sourceConfigState.fileName,
   });
   const homepageUrl = `https://${appSlug}.${effectiveOrganization}.deno.net`;
-  await writeWorkspaceManifestHomepage(repoRoot, homepageUrl);
   await setOutput("homepage_url", homepageUrl);
-  notice(
-    `Deployed '${appSlug}' and updated workspace manifest homepage_url to '${homepageUrl}'.`,
-  );
+  if (buildManifest) {
+    await writeWorkspaceManifestHomepage(repoRoot, homepageUrl);
+    notice(
+      `Deployed '${appSlug}' and updated workspace manifest homepage_url to '${homepageUrl}'.`,
+    );
 
-  await publishManifestArtifact({
-    github,
-    repoRoot,
-    sourceBranch: refName,
-    defaultBranch,
-    artifactBranch,
-  });
+    await publishManifestArtifact({
+      github,
+      repoRoot,
+      sourceBranch: refName,
+      defaultBranch,
+      artifactBranch,
+    });
+  } else {
+    notice(`Deployed '${appSlug}' at '${homepageUrl}'.`);
+  }
 }
 
 if (import.meta.main) {

--- a/scripts/provision_test.js
+++ b/scripts/provision_test.js
@@ -2,11 +2,12 @@ import { assertEquals } from "jsr:@std/assert@1.0.13";
 import { join } from "jsr:@std/path@1.1.2";
 import {
   buildConfig,
+  collectBuildEnvironmentVariables,
   parseEnvFileContent,
   stageWorkspaceDeployConfig,
 } from "./provision.js";
 
-Deno.test("buildConfig preserves source config and always enables kv", () => {
+Deno.test("buildConfig preserves source config, injects manifest build commands, and always enables kv by default", () => {
   const config = buildConfig("src/worker.ts", "ubiquity-os/example", {
     imports: {
       "foo/": "./foo/",
@@ -23,6 +24,12 @@ Deno.test("buildConfig preserves source config and always enables kv", () => {
   assertEquals(config.imports, {
     "foo/": "./foo/",
   });
+  assertEquals(config.install, "deno install");
+  assertEquals(
+    config.build,
+    "deno x -y @ubiquity-os/plugin-manifest-tool@latest --repository ubiquity-os/example --production-branch main",
+  );
+  assertEquals(config.predeploy, "deno install");
   assertEquals(config.unstable, ["bare-node-builtins", "kv"]);
   assertEquals(config.compilerOptions, {
     strict: true,
@@ -32,6 +39,56 @@ Deno.test("buildConfig preserves source config and always enables kv", () => {
     type: "dynamic",
     entrypoint: "src/worker.ts",
   });
+});
+
+Deno.test("buildConfig skips manifest build commands when buildManifest is disabled", () => {
+  const config = buildConfig(
+    "src/worker.ts",
+    "ubiquity-os/example",
+    {
+      imports: {
+        "foo/": "./foo/",
+      },
+      unstable: ["bare-node-builtins"],
+      build: "deno task build",
+      predeploy: "deno task predeploy",
+      runtime: {
+        custom: "value",
+      },
+    },
+    false,
+  );
+
+  assertEquals(config.imports, {
+    "foo/": "./foo/",
+  });
+  assertEquals(config.build, "deno task build");
+  assertEquals(config.predeploy, "deno task predeploy");
+  assertEquals(config.install, undefined);
+  assertEquals(config.unstable, ["bare-node-builtins", "kv"]);
+  assertEquals(config.runtime, {
+    custom: "value",
+    type: "dynamic",
+    entrypoint: "src/worker.ts",
+  });
+});
+
+Deno.test("collectBuildEnvironmentVariables omits manifest-specific variables when buildManifest is disabled", () => {
+  assertEquals(
+    collectBuildEnvironmentVariables({
+      repository: "ubiquity-os/example",
+      refName: "feature/test",
+      buildManifest: false,
+    }),
+    [
+      {
+        key: "REF_NAME",
+        value: "feature/test",
+        secret: false,
+        contexts: ["build"],
+      },
+    ],
+  );
 });
 
 Deno.test("parseEnvFileContent preserves escaped backslashes before newline decoding", () => {


### PR DESCRIPTION
## Summary
- add a `buildManifest` input to make plugin manifest handling optional
- skip manifest generation, manifest homepage writes, and `dist/*` publication when disabled
- keep `homepage_url` output populated for non-plugin Deno app deploys

## Why
`ubiquity-os-kernel` deploys a Deno app, not a plugin entrypoint, so the manifest tool assumptions fail. This keeps the Deno deploy flow intact while allowing non-plugin repos to opt out of the plugin manifest lifecycle.

## Testing
- `deno test scripts/provision_test.js --allow-all`

Closes #17